### PR TITLE
商品状態の項目追加訂正

### DIFF
--- a/app/models/condition_genre.rb
+++ b/app/models/condition_genre.rb
@@ -5,7 +5,7 @@ class ConditionGenre < ActiveHash::Base
     { id: 2, name: '未使用に近い' },
     { id: 3, name: '目立った傷や汚れなし' },
     { id: 4, name: 'やや傷や汚れあり' },
-    { id: 5, name: '傷や汚れあり' }
+    { id: 5, name: '傷や汚れあり' },
     { id: 6, name: '全体的に状態が悪い' }
   ]
 


### PR DESCRIPTION
# What
商品状態項目のid:5の項目の後ろに　,を追加した
# Why
最終挙動確認を実装するため